### PR TITLE
Adding GeoIp2 support.

### DIFF
--- a/app/code/community/Chapagain/AutoCurrency/Model/Store.php
+++ b/app/code/community/Chapagain/AutoCurrency/Model/Store.php
@@ -87,28 +87,28 @@ class Chapagain_AutoCurrency_Model_Store extends Mage_Core_Model_Store
      */
 	public function getCurrencyCodeMaxMind()
 	{
-		// include geoip.inc file
-		Mage::helper('autocurrency')->loadGeoIpInc();
-		
-		// get IP Address
-		$ipAddress = Mage::helper('autocurrency')->getIpAddress();
-		
-		// load GeoIP .dat binary file
-		if (Mage::helper('autocurrency')->checkIpv6($ipAddress)) {
-			$geoIp = Mage::helper('autocurrency')->loadGeoIpv6();
-		} else { 
-			$geoIp = Mage::helper('autocurrency')->loadGeoIpv4();
-		}	
-		
-		// get country code from ip address
-		$countryCode = geoip_country_code_by_addr($geoIp, $ipAddress);
-				
+
+        $ipAddress = Mage::helper('autocurrency')->getIpAddress();
+
+        $reader = new \GeoIp2\Database\Reader(BP . '/var/geoip/GeoLite2-Country.mmdb');
+
+        try{
+            $countryCode = $reader->country($ipAddress);
+            $countryCode = $countryCode->country->isoCode;
+        }catch (Exception $e){
+            return;
+        }
+
+        if(!$countryCode ){
+            return;
+        }
+
 		// get currency code from country code
 		//$currencyCode = geoip_currency_code_by_country_code($geoIp, $countryCode);
 		$currencyCode = Mage::helper('autocurrency')->getCurrencyByCountry($countryCode);
 		
 		// close the geo database  
-		geoip_close($geoIp);	
+//		geoip_close($geoIp);
 		
 		return $currencyCode;
 	}

--- a/app/code/community/Chapagain/AutoCurrency/Model/Store.php
+++ b/app/code/community/Chapagain/AutoCurrency/Model/Store.php
@@ -88,8 +88,35 @@ class Chapagain_AutoCurrency_Model_Store extends Mage_Core_Model_Store
 	public function getCurrencyCodeMaxMind()
 	{
 
+
+        $countryCode = $this->getCountryCodeByIp();
+
+		// get currency code from country code
+		$currencyCode = Mage::helper('autocurrency')->getCurrencyByCountry($countryCode);
+		
+
+		return $currencyCode;
+	}
+
+	public function getCountryCodeByIp()
+    {
         $ipAddress = Mage::helper('autocurrency')->getIpAddress();
 
+        $useMaxMind = !isset($_SERVER['HTTP_CF_IPCOUNTRY']);
+        if (Mage::registry('using_fake_ip')) { //this would come from Magenteiro_Cloudflare
+           $useMaxMind = true;
+        }
+
+        if ($useMaxMind) {
+            return $this->getCountryCodeFromMaxMind($ipAddress);
+        }
+
+        return $_SERVER['HTTP_CF_IPCOUNTRY'];
+
+    }
+
+    public function getCountryCodeFromMaxMind($ipAddress)
+    {
         $reader = new \GeoIp2\Database\Reader(BP . '/var/geoip/GeoLite2-Country.mmdb');
 
         try{
@@ -102,14 +129,6 @@ class Chapagain_AutoCurrency_Model_Store extends Mage_Core_Model_Store
         if(!$countryCode ){
             return;
         }
-
-		// get currency code from country code
-		//$currencyCode = geoip_currency_code_by_country_code($geoIp, $countryCode);
-		$currencyCode = Mage::helper('autocurrency')->getCurrencyByCountry($countryCode);
-		
-		// close the geo database  
-//		geoip_close($geoIp);
-		
-		return $currencyCode;
-	}
+        return $countryCode;
+    }
 }


### PR DESCRIPTION
This PR is just a suggestion of my implementation of GeoIp2 library.
Probably you'd like to import the GeoIp library instead of relying on composer and patched magentos. As my magento is already patched to support composer, I just need to change one of your files.

**To use GeoIp2 with this PR:**
You must do a "composer require geoip2/geoip2" and patch Magento to support composer.
After that, upload [GeoLite2-Country.mmdb](https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz) to var/geoip/.